### PR TITLE
Add updates for 2025.

### DIFF
--- a/ORGANIZERS
+++ b/ORGANIZERS
@@ -2,17 +2,19 @@ This contains a list of relevant contact points for the Rust devroom.
 
 ## Devroom contacts
 
-Initial organizers with access to FOSDEM penta:
+Organizers with access to FOSDEM pretalx:
 
 * Ewan Higgs (GH: ehiggs)
 * Luca Bruno (GH: lucab, IRC: kaeso)
-* Andy Georges (GH: itkovian)
 
-## Devroom volunteers
+## Previous organizers
+
+* Andy Georges (GH: itkovian)
+* Martin Junghanns (GH: s1ck)
+* Paul Horn (GH: knutwalker)
+
+## Thanks / Volunteers
 
 * Jan-Erik Rediger (GH: badboy)
 * Matthias Endler (GH: mre)
-
-Additional people helping with devroom organization:
-
 * Nicolas Silva (GH: nical, IRC: nical)

--- a/_posts/2015-01-01-intro.md
+++ b/_posts/2015-01-01-intro.md
@@ -5,19 +5,19 @@ color: black
 style: left
 ---
 
-# FOSDEM&#39;24 Rust Devroom
+# FOSDEM&#39;25 Rust Devroom
 
 <div style="text-align:center;">
-  <a href="https://fosdem.org/2024"><img src="img/rust-devroom-cfp-logo.png" height="200" width="148"/></a>
+  <a href="https://fosdem.org/2025"><img src="img/rust-devroom-cfp-logo.png" height="200" width="148"/></a>
 </div>
 
-### Saturday, 3 February 2024
+### Weekend of 1 & 2 February 2025
 ### Brussels, Belgium.
 
 ### Overview
 
 Welcome to the 5th edition of the Rust devroom,
-co-located with [FOSDEM 2024](https://fosdem.org/2024/). FOSDEM is an annual
+co-located with [FOSDEM 2025](https://fosdem.org/2025/). FOSDEM is an annual
 conference about free and open source software, attended by over 5000
 developers and open-source enthusiasts from all over the world.
 
@@ -25,7 +25,7 @@ The devroom is a colocated conference-within-a-conference that gives us the
 opportunity to come together and chat, hack, and share stories about Rust usage
 in FLOSS ecosystems.
 
-The devroom will take place on Saturday, 3 February 2024, at
+The devroom will take place on the weekend of 1 & 2 February 2025, at
 [ULB (Campus Solbosch)](https://www.openstreetmap.org/node/1632534522), in Brussels, Belgium. Join us to
 enjoy a full day of talks, demos and interesting discussions on Rust.
 

--- a/_posts/2015-01-02-topics.md
+++ b/_posts/2015-01-02-topics.md
@@ -11,13 +11,15 @@ We welcome any talk proposals about Rust-related projects.
 
 Topics of interest include, but are not limited to:
 
+ 
 - Rust as a modern and evolving language
     - New features and language initiatives
     - Architecting large projects
-- Rust usage across FLOSS projects (Linux, Tor, VLC, Gnome, Firefox, etc.)
+- Rust usage across FOSS user space projects (Tor, VLC, Gnome, Firefox, etc.)
+- Rust usage in FOSS (Linux[2], Redox[3], Android, etc.)
 - Projects written in Rust (show and tell)
 - Tooling
-    - Build tools (cargo, clippy, rustfmt, rust-analyzer, etc.)
+    - Build tools (cargo, clippy, rustfmt, etc)
     - Packaging libraries and executables written in Rust
     - Profiling, FFI, etc.
 - Documentation and education initiatives

--- a/_posts/2015-01-03-submissions.md
+++ b/_posts/2015-01-03-submissions.md
@@ -28,7 +28,7 @@ Submissions must include:
 <div style="text-align:center;">
   <p>
     <span style="font-size:20px;">
-      <a href="https://pretalx.fosdem.org/fosdem-2024/cfp">
+      <a href="https://pretalx.fosdem.org/fosdem-2025/cfp">
         <i class="fa fa-sign-in">&nbsp;<strong>Click here to submit.</strong></i>
       </a>
     </span>

--- a/_posts/2015-01-04-dates.md
+++ b/_posts/2015-01-04-dates.md
@@ -7,8 +7,8 @@ fa-icon: calendar
 icon-title: true
 ---
 
-Call for papers closes: 1 December 2023
+Call for papers closes: 1 December 2024
 
-Devroom schedule available: 15 December 2023
+Devroom schedule available: 15 December 2024
 
-Devroom day: Saturday 3 February 2024
+Devroom day: TBD, weekend of 1 & 2 February 2025

--- a/_posts/2015-01-05-organizers.md
+++ b/_posts/2015-01-05-organizers.md
@@ -11,8 +11,6 @@ encoding: utf-8
 ## Devroom Organizers
 
 * [Ewan Higgs](https://github.com/ehiggs)
-* [Martin Junghanns](https://github.com/s1ck)
 * [Luca Bruno](https://github.com/lucab)
-* [Paul Horn](https://github.com/knutwalker)
 
 Please, take a moment to read the [FOSDEM Code of Conduct](https://fosdem.org/2024/practical/conduct/).


### PR DESCRIPTION
The rust devroom was accepted again! Yay!

Update dates, themes, and organizers.

Thanks to all the previous organizers and volunteers!